### PR TITLE
update the api url

### DIFF
--- a/togglapi/api.py
+++ b/togglapi/api.py
@@ -22,15 +22,15 @@ class TogglAPI(object):
 
         >>> t = TogglAPI('_SECRET_TOGGLE_API_TOKEN_')
         >>> t._make_url(section='time_entries', params = {})
-        'https://www.toggl.com/api/v8/time_entries'
+        'https://api.track.toggl.com/api/v8/time_entries'
 
         >>> t = TogglAPI('_SECRET_TOGGLE_API_TOKEN_')
         >>> t._make_url(section='time_entries', 
                         params = {'start_date': '2010-02-05T15:42:46+02:00', 'end_date': '2010-02-12T15:42:46+02:00'})
-        'https://www.toggl.com/api/v8/time_entries?start_date=2010-02-05T15%3A42%3A46%2B02%3A00%2B02%3A00&end_date=2010-02-12T15%3A42%3A46%2B02%3A00%2B02%3A00'
+        'https://api.track.toggl.com/api/v8/time_entries?start_date=2010-02-05T15%3A42%3A46%2B02%3A00%2B02%3A00&end_date=2010-02-12T15%3A42%3A46%2B02%3A00%2B02%3A00'
         """
 
-        url = 'https://www.toggl.com/api/v8/{}'.format(section)
+        url = 'https://api.track.toggl.com/api/v8/{}'.format(section)
         if len(params) > 0:
             url = url + '?{}'.format(urlencode(params))
         return url


### PR DESCRIPTION
api url www.toggl.com was deprecated and replaced with api.track.toggl.com